### PR TITLE
Set Forbidden rather than Unauthorized on authorization failure

### DIFF
--- a/flask_bouncer.py
+++ b/flask_bouncer.py
@@ -4,7 +4,7 @@ from functools import wraps
 
 from flask import request, g, current_app, _app_ctx_stack as stack
 from werkzeug.local import LocalProxy
-from werkzeug.exceptions import Unauthorized
+from werkzeug.exceptions import Forbidden
 from bouncer import Ability
 from bouncer.constants import *
 
@@ -21,7 +21,7 @@ def ensure(action, subject):
     ability.aliased_actions = _bouncer.alias_actions
     if ability.cannot(action, subject):
         msg = "{0} does not have {1} access to {2}".format(current_user, action, subject)
-        raise Unauthorized(msg)
+        raise Forbidden(msg)
 
 # alais
 bounce = ensure
@@ -118,9 +118,9 @@ class Bouncer(object):
     def check_authorization(self, response):
         """checks that an authorization call has been made during the request"""
         if not hasattr(request, '_authorized'):
-            raise Unauthorized
+            raise Forbidden
         elif not request._authorized:
-            raise Unauthorized
+            raise Forbidden
         return response
 
     def check_implicit_rules(self):

--- a/test_flask_bouncer/test_basic_usage.py
+++ b/test_flask_bouncer/test_basic_usage.py
@@ -68,10 +68,10 @@ def test_not_allowed_index():
     doug = User(name='doug', admin=False)
     with user_set(app, doug):
         resp = client.get('/topsecret')
-        eq_(resp.status_code, 401)
+        eq_(resp.status_code, 403)
 
 def test_securing_specific_object():
     doug = User(name='doug', admin=False)
     with user_set(app, doug):
         resp = client.post('/article/1')
-        eq_(resp.status_code, 401)
+        eq_(resp.status_code, 403)

--- a/test_flask_bouncer/test_classy/__init__.py
+++ b/test_flask_bouncer/test_classy/__init__.py
@@ -61,7 +61,7 @@ def test_delete():
     # Non Admins should NOT be able to delete articles
     with user_set(app, nancy):
         resp = client.delete("/article/1234")
-        eq_(resp.status_code, 401)
+        eq_(resp.status_code, 403)
 
 def test_get():
     # admins should be able to view
@@ -128,7 +128,7 @@ def test_overwritten_get():
     # Non admins not be able to do this
     with user_set(app, nancy):
         resp = client.get("/overwritten/1234")
-        eq_(resp.status_code, 401)
+        eq_(resp.status_code, 403)
 
 
 

--- a/test_flask_bouncer/test_lock_it_down.py
+++ b/test_flask_bouncer/test_lock_it_down.py
@@ -1,12 +1,12 @@
 from flask import Flask
 from flask_bouncer import Bouncer, requires, skip_authorization, ensure
-from werkzeug.exceptions import Unauthorized
+from werkzeug.exceptions import Forbidden
 from bouncer.constants import *
 from nose.tools import *
 from .models import Article, User
 from .helpers import user_set
 
-@raises(Unauthorized)
+@raises(Forbidden)
 def test_lock_it_down_raise_exception():
 
     app = Flask("test_lock_it_down_raise_exception")
@@ -17,7 +17,7 @@ def test_lock_it_down_raise_exception():
     def define_authorization(user, they):
         they.can('browse', Article)
 
-    # Non decorated route -- should raise an Unauthorized
+    # Non decorated route -- should raise an Forbidden
     @app.route("/articles")
     def articles_index():
         return "A bunch of articles"
@@ -79,7 +79,7 @@ def test_bypass_route():
     def define_authorization(user, they):
         they.can('browse', Article)
 
-    # Non decorated route -- should raise an Unauthorized
+    # Non decorated route -- should raise an Forbidden
     @app.route("/articles")
     @skip_authorization
     def articles_index():


### PR DESCRIPTION
Based on my reading of the http error codes, a Forbidden (403) error is more
appropriate than Unauthorized (401), as Forbidden states:
"Raise if the user doesn’t have the permission for the requested resource but was authenticated."

As bouncer does not deal with authentication, and a 401 is used when
authentication errors occur, it makes more sense to raise a 403, on the
assumption that authentication has been already dealt with by another
component.
