### PR TITLE
Add support for Python 3.8

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 dist: xenial
 language: python
 python: 
-  - "2.7"
   - "3.5"
   - "3.6"
   - "3.7"
+  - "3.8"
   - "pypy3.5"
 install:
   - pip install tox

--- a/AUTHORS
+++ b/AUTHORS
@@ -5,6 +5,7 @@ Development Lead
 ````````````````
 
 - Jonathan Tushman <jonathan@zefr.com>
+- Fabian Becker <halfdan@xnorfz.de>
 
 Patches and Suggestions
 ```````````````````````

--- a/tox.ini
+++ b/tox.ini
@@ -1,10 +1,12 @@
 [tox]
-envlist=pypy,py36,py37
+envlist=pypy,py36,py37,py38
 [testenv]
 commands=python setup.py test
 [testenv:py36]
 basepython=python3.6
 [testenv:py37]
 basepython=python3.7
+[testenv:py38]
+basepython=python3.8
 [testenv:pypy]
 basepython=pypy


### PR DESCRIPTION
This PR adds testing for Python 3.8 to ensure we're compatible with this version of Python. Additionally it removes Python 2.7 from the test matrix.